### PR TITLE
activate-clang: don't set CODESIGN_ALLOCATE

### DIFF
--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -114,7 +114,7 @@ fi
 
 _tc_activation \
   activate host @CHOST@ @CHOST@- \
-  ar as checksyms codesign_allocate indr install_name_tool libtool lipo nm nmedit otool \
+  ar as checksyms indr install_name_tool libtool lipo nm nmedit otool \
   pagestuff ranlib redo_prebinding seg_addr_table seg_hack segedit size strings strip \
   ld \
   clang \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [win]
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
`conda smithy rerender` ended with :
> No changes made. This feedstock is up-to-date.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes conda-forge/clang-compiler-activation-feedstock#18
<!--
Please add any other relevant info below:
-->
Having this variable set prevents using the system `codesign` to sign binaries.

Don't set it.


