### PR TITLE
Don't activate if the target_platform is unexpected

### DIFF
--- a/recipe/activate-clang++.sh
+++ b/recipe/activate-clang++.sh
@@ -79,6 +79,7 @@ function _tc_activation() {
   return 0
 }
 
+function activate_clangxx() {
 # When people are using conda-build, assume that adding rpath during build, and pointing at
 #    the host env's includes and libs is helpful default behavior
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
@@ -117,4 +118,11 @@ else
     diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
     rm -f /tmp/old-env-$$.txt /tmp/new-env-$$.txt || true
   fi
+fi
+}
+
+if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && [ "${target_platform:-@TARGET_PLATFORM@}" -ne "@TARGET_PLATFORM@" ]; then
+   echo "Not activating environment because this compiler is not expected."
+else
+  activate_clangxx
 fi

--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -79,6 +79,7 @@ function _tc_activation() {
   return 0
 }
 
+function activate_clang() {
 # When people are using conda-build, assume that adding rpath during build, and pointing at
 #    the host env's includes and libs is helpful default behavior
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
@@ -194,4 +195,11 @@ else
     diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
     rm -f /tmp/old-env-$$.txt /tmp/new-env-$$.txt || true
   fi
+fi
+}
+
+if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && [ "${target_platform:-@TARGET_PLATFORM@}" -ne "@TARGET_PLATFORM@" ]; then
+  echo "Not activating environment because this compiler is not expected."
+else
+  activate_clang
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -49,4 +49,5 @@ find . -name "*activate*.sh" -exec sed -i.bak "s|@_PYTHON_SYSCONFIGDATA_NAME@|${
 find . -name "*activate*.sh" -exec sed -i.bak "s|@UNAME_MACHINE@|${uname_machine}|g"         "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@MESON_CPU_FAMILY@|${meson_cpu_family}|g"         "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@UNAME_KERNEL_RELEASE@|${uname_kernel_release}|g"         "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@TARGET_PLATFORM@|${cross_target_platform}|g"         "{}" \;
 find . -name "*activate*.sh.bak" -exec rm "{}" \;

--- a/recipe/deactivate-clang++.sh
+++ b/recipe/deactivate-clang++.sh
@@ -79,6 +79,8 @@ function _tc_activation() {
   return 0
 }
 
+function deactivate_clangxx() {
+
 # When people are using conda-build, assume that adding rpath during build, and pointing at
 #    the host env's includes and libs is helpful default behavior
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
@@ -117,4 +119,11 @@ else
     diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
     rm -f /tmp/old-env-$$.txt /tmp/new-env-$$.txt || true
   fi
+fi
+}
+
+if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && [ "${target_platform:-@TARGET_PLATFORM@}" -ne "@TARGET_PLATFORM@" ]; then
+  echo "Not deactivating environment because this compiler is not expected."
+else
+  deactivate_clangxx
 fi

--- a/recipe/deactivate-clang.sh
+++ b/recipe/deactivate-clang.sh
@@ -79,6 +79,9 @@ function _tc_activation() {
   return 0
 }
 
+
+function deactivate_clang() {
+
 # When people are using conda-build, assume that adding rpath during build, and pointing at
 #    the host env's includes and libs is helpful default behavior
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
@@ -155,4 +158,11 @@ else
     diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
     rm -f /tmp/old-env-$$.txt /tmp/new-env-$$.txt || true
   fi
+fi
+}
+
+if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && [ "${target_platform:-@TARGET_PLATFORM@}" -ne "@TARGET_PLATFORM@" ]; then
+  echo "Not deactivating environment because this compiler is not expected."
+else
+  deactivate_clang
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 5
+  number: 6
 
 requirements:
   build:


### PR DESCRIPTION
This is needed because r-base brings in the compiler for build platform
when cross-compiling which is undesirable

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
