### PR TITLE
Fix macOS code signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,8 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-clang_bootstrap_osx--64-green.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clang_bootstrap_osx-64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clang_bootstrap_osx-64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clang_bootstrap_osx-64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-clang_bootstrap_osx--arm64-green.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clang_bootstrap_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clang_bootstrap_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clang_bootstrap_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-arm64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-clang_osx--64-green.svg)](https://anaconda.org/conda-forge/clang_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clang_osx-64.svg)](https://anaconda.org/conda-forge/clang_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clang_osx-64.svg)](https://anaconda.org/conda-forge/clang_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clang_osx-64.svg)](https://anaconda.org/conda-forge/clang_osx-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-clang_osx--arm64-green.svg)](https://anaconda.org/conda-forge/clang_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clang_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clang_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clang_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_osx-arm64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-clangxx_osx--64-green.svg)](https://anaconda.org/conda-forge/clangxx_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clangxx_osx-64.svg)](https://anaconda.org/conda-forge/clangxx_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clangxx_osx-64.svg)](https://anaconda.org/conda-forge/clangxx_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clangxx_osx-64.svg)](https://anaconda.org/conda-forge/clangxx_osx-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-clangxx_osx--arm64-green.svg)](https://anaconda.org/conda-forge/clangxx_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clangxx_osx-arm64.svg)](https://anaconda.org/conda-forge/clangxx_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clangxx_osx-arm64.svg)](https://anaconda.org/conda-forge/clangxx_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clangxx_osx-arm64.svg)](https://anaconda.org/conda-forge/clangxx_osx-arm64) |
 
 Installing clang-compiler-activation
@@ -97,16 +94,16 @@ Installing `clang-compiler-activation` from the `conda-forge` channel can be ach
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `clang_bootstrap_osx-64, clang_bootstrap_osx-arm64, clang_osx-64, clang_osx-arm64, clangxx_osx-64, clangxx_osx-arm64` can be installed with:
+Once the `conda-forge` channel has been enabled, `clang_bootstrap_osx-arm64, clang_osx-arm64, clangxx_osx-arm64` can be installed with:
 
 ```
-conda install clang_bootstrap_osx-64 clang_bootstrap_osx-arm64 clang_osx-64 clang_osx-arm64 clangxx_osx-64 clangxx_osx-arm64
+conda install clang_bootstrap_osx-arm64 clang_osx-arm64 clangxx_osx-arm64
 ```
 
-It is possible to list all of the versions of `clang_bootstrap_osx-64` available on your platform with:
+It is possible to list all of the versions of `clang_bootstrap_osx-arm64` available on your platform with:
 
 ```
-conda search clang_bootstrap_osx-64 --channel conda-forge
+conda search clang_bootstrap_osx-arm64 --channel conda-forge
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-clang_bootstrap_osx--arm64-green.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clang_bootstrap_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clang_bootstrap_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clang_bootstrap_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-arm64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-clang_osx--arm64-green.svg)](https://anaconda.org/conda-forge/clang_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clang_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clang_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clang_osx-arm64.svg)](https://anaconda.org/conda-forge/clang_osx-arm64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-clangxx_osx--arm64-green.svg)](https://anaconda.org/conda-forge/clangxx_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clangxx_osx-arm64.svg)](https://anaconda.org/conda-forge/clangxx_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clangxx_osx-arm64.svg)](https://anaconda.org/conda-forge/clangxx_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clangxx_osx-arm64.svg)](https://anaconda.org/conda-forge/clangxx_osx-arm64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-clang_bootstrap_osx--64-green.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clang_bootstrap_osx-64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clang_bootstrap_osx-64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clang_bootstrap_osx-64.svg)](https://anaconda.org/conda-forge/clang_bootstrap_osx-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-clang_osx--64-green.svg)](https://anaconda.org/conda-forge/clang_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clang_osx-64.svg)](https://anaconda.org/conda-forge/clang_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clang_osx-64.svg)](https://anaconda.org/conda-forge/clang_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clang_osx-64.svg)](https://anaconda.org/conda-forge/clang_osx-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-clangxx_osx--64-green.svg)](https://anaconda.org/conda-forge/clangxx_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/clangxx_osx-64.svg)](https://anaconda.org/conda-forge/clangxx_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/clangxx_osx-64.svg)](https://anaconda.org/conda-forge/clangxx_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/clangxx_osx-64.svg)](https://anaconda.org/conda-forge/clangxx_osx-64) |
 
 Installing clang-compiler-activation
 ====================================
@@ -94,16 +94,16 @@ Installing `clang-compiler-activation` from the `conda-forge` channel can be ach
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `clang_bootstrap_osx-arm64, clang_osx-arm64, clangxx_osx-arm64` can be installed with:
+Once the `conda-forge` channel has been enabled, `clang_bootstrap_osx-64, clang_osx-64, clangxx_osx-64` can be installed with:
 
 ```
-conda install clang_bootstrap_osx-arm64 clang_osx-arm64 clangxx_osx-arm64
+conda install clang_bootstrap_osx-64 clang_osx-64 clangxx_osx-64
 ```
 
-It is possible to list all of the versions of `clang_bootstrap_osx-arm64` available on your platform with:
+It is possible to list all of the versions of `clang_bootstrap_osx-64` available on your platform with:
 
 ```
-conda search clang_bootstrap_osx-arm64 --channel conda-forge
+conda search clang_bootstrap_osx-64 --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 
 requirements:
   build:
+    - cctools_{{ target_platform }}  # [osx]
     - libcxx {{ version }}
     - gcc_{{ target_platform }}       # [linux]
     - clang {{ version }}                  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,25 +25,23 @@ outputs:
   - name: clang_{{ cross_target_platform }}
     script: install-clang.sh
     requirements:
-      build:
-        - cctools_{{ target_platform }}
-      host:
-        - clang {{ version }}
-        - llvm-tools {{ version }}
-        - cctools_{{ cross_target_platform }}
-        - ld64_{{ cross_target_platform }}
-        - ld64_{{ target_platform }}          # [osx]
-        # this brings in an extra symlink of ld -> x86_64-apple-darwin13.4.0-ld
-        # adding these generated an error w/ libtool: https://github.com/conda-forge/libtool-feedstock/issues/24
-        # - ld64     # [cross_target_platform == target_platform]
-        # - cctools  # [cross_target_platform == target_platform]
-        # This brings in libraries for linux too. Split this again?
-        - compiler-rt {{ version }}
-        # For OSX, compiler-rt library includes both x86_64 and arm64.
-        # Therefore `compiler-rt_osx-64` and `compiler-rt_osx-arm64` are basically the same
-        # and clobber each other. Don't bring both here.
-        - compiler-rt_{{ cross_target_platform }} {{ version }}     # [linux]
-        - gcc_impl_{{ target_platform }}       # [linux]
+      - clang {{ version }}
+      - llvm-tools {{ version }}
+      - cctools_{{ target_platform }}
+      - cctools_{{ cross_target_platform }}
+      - ld64_{{ cross_target_platform }}
+      - ld64_{{ target_platform }}          # [osx]
+      # this brings in an extra symlink of ld -> x86_64-apple-darwin13.4.0-ld
+      # adding these generated an error w/ libtool: https://github.com/conda-forge/libtool-feedstock/issues/24
+      # - ld64     # [cross_target_platform == target_platform]
+      # - cctools  # [cross_target_platform == target_platform]
+      # This brings in libraries for linux too. Split this again?
+      - compiler-rt {{ version }}
+      # For OSX, compiler-rt library includes both x86_64 and arm64.
+      # Therefore `compiler-rt_osx-64` and `compiler-rt_osx-arm64` are basically the same
+      # and clobber each other. Don't bring both here.
+      - compiler-rt_{{ cross_target_platform }} {{ version }}     # [linux]
+      - gcc_impl_{{ target_platform }}       # [linux]
     test:
       commands:
         - {{ CBUILD }}-clang --version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,22 +24,25 @@ outputs:
   - name: clang_{{ cross_target_platform }}
     script: install-clang.sh
     requirements:
-      - clang {{ version }}
-      - llvm-tools {{ version }}
-      - cctools_{{ cross_target_platform }}
-      - ld64_{{ cross_target_platform }}
-      - ld64_{{ target_platform }}          # [osx]
-      # this brings in an extra symlink of ld -> x86_64-apple-darwin13.4.0-ld
-      # adding these generated an error w/ libtool: https://github.com/conda-forge/libtool-feedstock/issues/24
-      # - ld64     # [cross_target_platform == target_platform]
-      # - cctools  # [cross_target_platform == target_platform]
-      # This brings in libraries for linux too. Split this again?
-      - compiler-rt {{ version }}
-      # For OSX, compiler-rt library includes both x86_64 and arm64.
-      # Therefore `compiler-rt_osx-64` and `compiler-rt_osx-arm64` are basically the same
-      # and clobber each other. Don't bring both here.
-      - compiler-rt_{{ cross_target_platform }} {{ version }}     # [linux]
-      - gcc_impl_{{ target_platform }}       # [linux]
+      build:
+        - cctools_{{ target_platform }}  # [osx]
+      host:
+        - clang {{ version }}
+        - llvm-tools {{ version }}
+        - cctools_{{ cross_target_platform }}
+        - ld64_{{ cross_target_platform }}
+        - ld64_{{ target_platform }}          # [osx]
+        # this brings in an extra symlink of ld -> x86_64-apple-darwin13.4.0-ld
+        # adding these generated an error w/ libtool: https://github.com/conda-forge/libtool-feedstock/issues/24
+        # - ld64     # [cross_target_platform == target_platform]
+        # - cctools  # [cross_target_platform == target_platform]
+        # This brings in libraries for linux too. Split this again?
+        - compiler-rt {{ version }}
+        # For OSX, compiler-rt library includes both x86_64 and arm64.
+        # Therefore `compiler-rt_osx-64` and `compiler-rt_osx-arm64` are basically the same
+        # and clobber each other. Don't bring both here.
+        - compiler-rt_{{ cross_target_platform }} {{ version }}     # [linux]
+        - gcc_impl_{{ target_platform }}       # [linux]
     test:
       commands:
         - {{ CBUILD }}-clang --version
@@ -48,6 +51,8 @@ outputs:
   - name: clangxx_{{ cross_target_platform }}
     script: install-clangxx.sh
     requirements:
+      build:
+        - cctools_{{ target_platform }}  # [osx]
       host:
         - clangxx {{ version }}
         - libcxx {{ version }}  # [osx]
@@ -80,6 +85,8 @@ outputs:
   - name: clang_bootstrap_{{ cross_target_platform }}
     script: install-clang-bootstrap.sh
     requirements:
+      build:
+        - cctools_{{ target_platform }}  # [osx]
       host:
         - clangxx {{ version }}
         - libcxx {{ version }}                # [cross_target_platform in ("osx-64", "osx-arm64")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   build:
-    - cctools_{{ target_platform }}  # [osx]
+    - cctools_{{ target_platform }}
     - libcxx {{ version }}
     - gcc_{{ target_platform }}       # [linux]
     - clang {{ version }}                  # [osx]
@@ -26,7 +26,7 @@ outputs:
     script: install-clang.sh
     requirements:
       build:
-        - cctools_{{ target_platform }}  # [osx]
+        - cctools_{{ target_platform }}
       host:
         - clang {{ version }}
         - llvm-tools {{ version }}
@@ -53,9 +53,10 @@ outputs:
     script: install-clangxx.sh
     requirements:
       build:
-        - cctools_{{ target_platform }}  # [osx]
+        - cctools_{{ target_platform }}
       host:
         - clangxx {{ version }}
+        - cctools_{{ cross_target_platform }}
         - libcxx {{ version }}  # [osx]
         - {{ pin_subpackage('clang_' ~ cross_target_platform, exact=True) }}
         - gxx_impl_{{ target_platform }}     # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   build:
-    - cctools_{{ target_platform }}
+    - cctools_{{ target_platform }}  # [osx]
     - libcxx {{ version }}
     - gcc_{{ target_platform }}       # [linux]
     - clang {{ version }}                  # [osx]
@@ -27,7 +27,7 @@ outputs:
     requirements:
       - clang {{ version }}
       - llvm-tools {{ version }}
-      - cctools_{{ target_platform }}
+      - cctools_{{ target_platform }}  # [osx]
       - cctools_{{ cross_target_platform }}
       - ld64_{{ cross_target_platform }}
       - ld64_{{ target_platform }}          # [osx]
@@ -51,10 +51,9 @@ outputs:
     script: install-clangxx.sh
     requirements:
       build:
-        - cctools_{{ target_platform }}
+        - cctools_{{ target_platform }}  # [osx]
       host:
         - clangxx {{ version }}
-        - cctools_{{ cross_target_platform }}
         - libcxx {{ version }}  # [osx]
         - {{ pin_subpackage('clang_' ~ cross_target_platform, exact=True) }}
         - gxx_impl_{{ target_platform }}     # [linux]


### PR DESCRIPTION
Fixes #49 

`clang_bootstrap_` is currently not working on `osx-arm64` as the code signatures are invalid. This fixes it by adding `cctools` to all build environments so that `conda-build` will pick up the right tools on correcting paths.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
