### PR TITLE
clang-compiler-activation v12.0.1 (redux)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0:

--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -157,7 +157,7 @@ _tc_activation \
   activate @CHOST@- "HOST,@CHOST@" \
   "CONDA_TOOLCHAIN_HOST,@CHOST@" \
   "CONDA_TOOLCHAIN_BUILD,@CBUILD@" \
-  ar as checksyms indr install_name_tool libtool lipo nm nmedit otool \
+  ar as checksyms install_name_tool libtool lipo nm nmedit otool \
   pagestuff ranlib redo_prebinding seg_addr_table seg_hack segedit size strings strip \
   clang ld \
   "CC,${CC:-@CHOST@-clang}" \

--- a/recipe/deactivate-clang.sh
+++ b/recipe/deactivate-clang.sh
@@ -127,7 +127,7 @@ _tc_activation \
   deactivate @CHOST@- "HOST,@CHOST@" \
   "CONDA_TOOLCHAIN_HOST,@CHOST@" \
   "CONDA_TOOLCHAIN_BUILD,@CBUILD@" \
-  ar as checksyms indr install_name_tool libtool lipo nm nmedit otool \
+  ar as checksyms install_name_tool libtool lipo nm nmedit otool \
   pagestuff ranlib redo_prebinding seg_addr_table seg_hack segedit size strings strip \
   clang ld \
   "CC,${CC:-@CHOST@-clang}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "11.1.0" %}
+{% set version = "12.0.1" %}
 {% set major_ver = version.split(".")[0] %}
 
 package:
@@ -8,11 +8,11 @@ package:
 # Not strictly needed but enables automatic updates from the bot
 source:
   url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
-  sha256: 74d2529159fd118c3eac6f90107b5611bccc6f647fdea104024183e8d5e25831
+  sha256: 129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Upstream cctools does not support `indr` anymore, see [this](https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/63#issuecomment-880241992) comment.

Closes #63 
Closes #62 