### PR TITLE
LLVM 15.0.7

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -32,5 +32,5 @@ zip_keys:
     - uname_kernel_release
     - FINAL_PYTHON_SYSCONFIGDATA_NAME
 version:
-  - 13.0.1
   - 14.0.6
+  - 15.0.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,8 +3,11 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-# make sure this does not reset (unless affected older LLVMs get dropped)
-{% set build_number = 4 %}
+{% set build_number = 0 %}
+# keep build number increments for old compiler versions as necessary
+{% if major_ver | int < 15 %}
+{% set build_number = build_number + 4 %}
+{% endif %}
 
 package:
   name: clang-compiler-activation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% if version is not defined %}
-{% set version = "14.0.6" %}
+{% set version = "15.0.7" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 


### PR DESCRIPTION
Manual PR because the bot doesn't work anymore now that this recipe has several LLVM versions at the same time.

Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency; c.f. list from [14.x](https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/82#issue-1178735569)):

* [x] https://github.com/conda-forge/llvmdev-feedstock/pull/194 [^1]
  * [x] https://github.com/conda-forge/clangdev-feedstock/pull/197
    * [x] https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/57
    * [x] https://github.com/conda-forge/compiler-rt-feedstock/pull/58
      * [x] https://github.com/conda-forge/clang-win-activation-feedstock/pull/17 **
      * [ ] https://github.com/conda-forge/flang-feedstock (NEW! also [depends](https://github.com/llvm/llvm-project/tree/main/flang#building-flang-in-tree) on openmp/mlir) **
    * [x] https://github.com/conda-forge/libcxx-feedstock/pull/108
  * [x] https://github.com/conda-forge/lld-feedstock/pull/51
  * [x] https://github.com/conda-forge/mlir-feedstock/pull/31 **
  * [x] https://github.com/conda-forge/openmp-feedstock/pull/76
  
The PRs marked ** are not strictly speaking necessary for merging this PR, but for LLVM 15.x support in conda-forge.

[^1]: though really openmp/lld/compiler-rt had been blocked on https://github.com/conda-forge/llvmdev-feedstock/pull/190