### PR TITLE
extend ${BUILD_PREFIX}/meson_cross_file.txt with pkgconfig & cmake setup

### DIFF
--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -153,6 +153,14 @@ if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
   echo "cpu = '@UNAME_MACHINE@'" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "cpu_family = '@MESON_CPU_FAMILY@'" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "endian = 'little'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  # specify path to correct binaries/metadata the meson will not auto-discover out of caution
+  # binaries from build env
+  echo "[binaries]" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "cmake = '${CONDA_PREFIX}/bin/cmake'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "pkgconfig = '${CONDA_PREFIX}/bin/pkg-config'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  # metadata from host env
+  echo "[properties]" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "pkg_config_libdir = '${PREFIX}/lib'" >> ${CONDA_PREFIX}/meson_cross_file.txt
 fi
 
 _tc_activation \

--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -153,14 +153,11 @@ if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
   echo "cpu = '@UNAME_MACHINE@'" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "cpu_family = '@MESON_CPU_FAMILY@'" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "endian = 'little'" >> ${CONDA_PREFIX}/meson_cross_file.txt
-  # specify path to correct binaries/metadata the meson will not auto-discover out of caution
-  # binaries from build env
+  # specify path to correct binaries from build (not host) environment,
+  # which meson will not auto-discover (out of caution) if not told explicitly.
   echo "[binaries]" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "cmake = '${CONDA_PREFIX}/bin/cmake'" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "pkgconfig = '${CONDA_PREFIX}/bin/pkg-config'" >> ${CONDA_PREFIX}/meson_cross_file.txt
-  # metadata from host env
-  echo "[properties]" >> ${CONDA_PREFIX}/meson_cross_file.txt
-  echo "pkg_config_libdir = '${PREFIX}/lib'" >> ${CONDA_PREFIX}/meson_cross_file.txt
 fi
 
 _tc_activation \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 # keep build number increments for old compiler versions as necessary
 {% if major_ver | int <= 14 %}
 {% set build_number = build_number + 5 %}


### PR DESCRIPTION
meson will not auto-discover cmake/pkgconfig in the context of cross-compilation; it needs to be specified explicitly; same goes for the pkgconfig-metadata.

Add this to the default `meson_cross_file.txt` that's generated for our osx cross-compilation, so we don't have to add this manually (like in https://github.com/conda-forge/scipy-feedstock/pull/205 currently).

I _presume_ that the presence of these extra lines should not affect cross-compilation cases where either `cmake` or `pkgconfig` is not actually available. Perhaps @eli-schwartz can confirm/deny?

In any case, would appreciate your inputs @isuruf