### PR TITLE
Rebuild for libxml2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 # keep build number increments for old compiler versions as necessary
 {% if major_ver | int <= 15 %}
 {% set build_number = build_number + 1 %}


### PR DESCRIPTION
Ensure that compilers can be co-installed with the new libcxx in the same environment