### PR TITLE
LLVM 18.1.4

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,8 +16,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3:
-        CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3
+      linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4:
+        CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6:
@@ -28,8 +28,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3:
-        CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3
+      linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4:
+        CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,8 +14,8 @@ jobs:
       osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6:
         CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3:
-        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3
+      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4:
+        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4
         UPLOAD_PACKAGES: 'True'
       osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6:
         CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6
@@ -23,8 +23,8 @@ jobs:
       osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6:
         CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3:
-        CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3
+      osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4:
+        CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4
         UPLOAD_PACKAGES: 'True'
       osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version16.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version16.0.6
@@ -32,8 +32,8 @@ jobs:
       osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3:
-        CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3
+      osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4:
+        CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4
         UPLOAD_PACKAGES: 'True'
       osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6
@@ -41,8 +41,8 @@ jobs:
       osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3
+      osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4:
+        CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4.yaml
@@ -29,7 +29,7 @@ uname_kernel_release:
 uname_machine:
 - x86_64
 version:
-- 18.1.3
+- 18.1.4
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4.yaml
@@ -1,32 +1,38 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-macos_machine:
-- x86_64-apple-darwin13.4.0
-meson_cpu_family:
-- x86_64
-target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+macos_machine:
+- arm64-apple-darwin20.0.0
+meson_cpu_family:
+- aarch64
+target_platform:
+- linux-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 18.1.3
+- 18.1.4
 zip_keys:
+- - c_stdlib_version
+  - cdt_name
 - - cross_target_platform
   - macos_machine
   - meson_cpu_family

--- a/.ci_support/osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4.yaml
@@ -25,7 +25,7 @@ uname_kernel_release:
 uname_machine:
 - x86_64
 version:
-- 18.1.3
+- 18.1.4
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4.yaml
@@ -1,13 +1,13 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,13 +19,13 @@ macos_machine:
 meson_cpu_family:
 - aarch64
 target_platform:
-- osx-arm64
+- osx-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 18.1.3
+- 18.1.4
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4.yaml
@@ -1,38 +1,32 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.12'
-cdt_name:
-- cos6
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 target_platform:
-- linux-64
+- osx-arm64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 18.1.3
+- 18.1.4
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - cross_target_platform
   - macos_machine
   - meson_cpu_family

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4.yaml
@@ -1,13 +1,13 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.9'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,13 +19,13 @@ macos_machine:
 meson_cpu_family:
 - aarch64
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 18.1.3
+- 18.1.4
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Package license: BSD-3-Clause
 
 Summary: clang compilers for conda-build 3
 
-About clang_bootstrap_osx-arm64
--------------------------------
+About clang_bootstrap_osx-64
+----------------------------
 
 Home: https://llvm.org
 
@@ -22,8 +22,8 @@ Package license: Apache-2.0
 
 Summary: clang compiler components in one package for bootstrapping clang
 
-About clang_bootstrap_osx-64
-----------------------------
+About clang_bootstrap_osx-arm64
+-------------------------------
 
 Home: https://llvm.org
 
@@ -63,10 +63,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3</td>
+              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -84,10 +84,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3</td>
+              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -105,10 +105,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3</td>
+              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -126,10 +126,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3</td>
+              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -147,10 +147,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3</td>
+              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.4" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -168,10 +168,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3</td>
+              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.4" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:  # [linux]
 version:
   - 16.0.6
   - 17.0.6
-  - 18.1.3
+  - 18.1.4
 
 # everything below is zipped
 cross_target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% if version is not defined %}
-{% set version = "18.1.3" %}
+{% set version = "18.1.4" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 # cannot yet build libcxx 17 due to having no
@@ -7,7 +7,7 @@
 # so allow the last major version of libcxx
 {% set libcxx_major = 16 %}
 
-{% set build_number = 11 %}
+{% set build_number = 12 %}
 
 package:
   name: clang-compiler-activation


### PR DESCRIPTION
Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency; c.f. list from #123):

* [ ] https://github.com/conda-forge/llvmdev-feedstock/pull/261
  * [ ] `clangdev`
    * [ ] `cctools-and-ld64-feedstock`
    * [ ] `compiler-rt-feedstock`
      * [ ] `openmp-feedstock`
    * [ ] https://github.com/conda-forge/libcxx-feedstock/pull/131 (waiting for MacOS 10.13 roll-out)
  * [ ] `lld-feedstock`

Related feedstocks for LLVM 18.1.4 support more generally:
* [ ] `clang-win-activation-feedstock` (windows side of this PR; needs this PR)
* [ ] `ctng-compiler-activation-feedstock` (linux side of this PR; needs this PR)
* [ ] `flang-feedstock` (needs mlir, openmp, compiler-rt)
* [ ] `libcxx-testing-feedstock` (needs this PR)
* [ ] `lldb-feedstock` (needs this PR)
* [ ] `mlir-feedstock` (needs llvmdev)
* [ ] `mlir-python-bindings-feedstock` (needs llvmdev & mlir)