### PR TITLE
support using libcxx 17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,12 +2,14 @@
 {% set version = "18.1.5" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
-# cannot yet build libcxx 17 due to having no
-# infrastructure to enforce `__osx >=10.13` properly,
-# so allow the last major version of libcxx
+# first version requiring `__osx >=10.13`; libcxx 18 still in progress
+{% if major_ver|int >= 17 %}
+{% set libcxx_major = 17 %}
+{% else %}
 {% set libcxx_major = 16 %}
+{% endif %}
 
-{% set build_number = 13 %}
+{% set build_number = 14 %}
 
 package:
   name: clang-compiler-activation


### PR DESCRIPTION
Now that https://github.com/conda-forge/libcxx-feedstock/pull/131 has finally been merged, support its use with the cxx compilers. We cannot yet go back to the pre-17 days of just requiring `version` for libcxx directly (c.f. https://github.com/conda-forge/clang-compiler-activation-feedstock/commit/db8e474173b3735d91c5de7d261a5911c78db516) until we also have [libcxx 18](https://github.com/conda-forge/libcxx-feedstock/pull/144), which might still take a little while.

Also, holding off on the release of 18 allows us to judge the impact of libcxx 17 on the broader ecosystem a bit better (and adapt to deprecations etc. as necessary), rather than jumping by 2 major versions in one go.