### PR TITLE
LLVM 18.1.7

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,8 +16,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6:
-        CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6
+      linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7:
+        CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6:
@@ -28,8 +28,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6:
-        CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6
+      linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7:
+        CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,8 +14,8 @@ jobs:
       osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6:
         CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6:
-        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6
+      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7:
+        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7
         UPLOAD_PACKAGES: 'True'
       osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6:
         CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6
@@ -23,8 +23,8 @@ jobs:
       osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6:
         CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6:
-        CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6
+      osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7:
+        CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7
         UPLOAD_PACKAGES: 'True'
       osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version16.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version16.0.6
@@ -32,8 +32,8 @@ jobs:
       osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6:
-        CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6
+      osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7:
+        CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7
         UPLOAD_PACKAGES: 'True'
       osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version16.0.6
@@ -41,8 +41,8 @@ jobs:
       osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6
+      osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7:
+        CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7.yaml
@@ -1,7 +1,7 @@
 CBUILD:
 - x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 cdt_name:
@@ -11,21 +11,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 target_platform:
 - linux-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 18.1.6
+- 18.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7.yaml
@@ -1,29 +1,31 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-macos_machine:
-- x86_64-apple-darwin13.4.0
-meson_cpu_family:
-- x86_64
-target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+macos_machine:
+- arm64-apple-darwin20.0.0
+meson_cpu_family:
+- aarch64
+target_platform:
+- linux-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 18.1.6
+- 18.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7.yaml
@@ -1,29 +1,29 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 target_platform:
-- osx-arm64
+- osx-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 18.1.6
+- 18.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7.yaml
@@ -1,31 +1,29 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos6
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- osx-arm64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 18.1.6
+- 18.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7.yaml
@@ -1,11 +1,11 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,13 +17,13 @@ macos_machine:
 meson_cpu_family:
 - x86_64
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 18.1.6
+- 18.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7.yaml
@@ -1,11 +1,11 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,13 +17,13 @@ macos_machine:
 meson_cpu_family:
 - aarch64
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 18.1.6
+- 18.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6</td>
+              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -84,10 +84,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6</td>
+              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -105,10 +105,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6</td>
+              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -126,10 +126,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6</td>
+              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -147,10 +147,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6</td>
+              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -168,10 +168,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6</td>
+              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.7" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:  # [linux]
 version:
   - 16.0.6
   - 17.0.6
-  - 18.1.6
+  - 18.1.7
 
 # everything below is zipped
 cross_target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% if version is not defined %}
-{% set version = "18.1.6" %}
+{% set version = "18.1.7" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 # first version requiring `__osx >=10.13`; libcxx 18 still in progress
@@ -9,7 +9,7 @@
 {% set libcxx_major = 16 %}
 {% endif %}
 
-{% set build_number = 15 %}
+{% set build_number = 16 %}
 
 package:
   name: clang-compiler-activation


### PR DESCRIPTION
Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency):

* [x] https://github.com/conda-forge/llvmdev-feedstock/pull/266
  * [x] https://github.com/conda-forge/clangdev-feedstock/pull/287
    * [x] https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/65 (only needs major version)
    * [x] https://github.com/conda-forge/compiler-rt-feedstock/pull/108
      * [x] https://github.com/conda-forge/openmp-feedstock/pull/127
    * [ ] https://github.com/conda-forge/libcxx-feedstock/pull/144 (still using libcxx 17 here for now)
  * [x] https://github.com/conda-forge/lld-feedstock/pull/93

Related feedstocks for LLVM 18.1.7 support more generally:
* [ ] https://github.com/conda-forge/clang-win-activation-feedstock/pull/37 (windows side of this PR; needs this PR)
* [x] https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/104 (only needs major version)
* [ ] https://github.com/conda-forge/flang-feedstock/pull/51 (needs mlir, compiler-rt, openmp)
* [x] https://github.com/conda-forge/libcxx-testing-feedstock/pull/6 (only needs major version)
* [ ] https://github.com/conda-forge/lldb-feedstock/pull/68 (needs this PR)
* [x] https://github.com/conda-forge/mlir-feedstock/pull/71 (needs llvmdev)
* [x] https://github.com/conda-forge/mlir-python-bindings-feedstock/pull/29 (needs llvmdev & mlir)