### PR TITLE
add symlinks for $TRIPLE-clang-cpp

### DIFF
--- a/recipe/install-clang.sh
+++ b/recipe/install-clang.sh
@@ -6,9 +6,11 @@ CHOST=${macos_machine}
 
 pushd "${PREFIX}"/bin
   ln -s clang ${CHOST}-clang
+  ln -s clang-cpp ${CHOST}-clang-cpp
   if [[ "${CBUILD}" != ${CHOST} ]] && [[ "${target_platform}" != linux-* ]]; then
     # on linux, the `clang` package already has a $TRIPLE-clang, see
     # https://github.com/conda-forge/clangdev-feedstock/pull/251
     ln -s clang ${CBUILD}-clang
+    ln -s clang-cpp ${CBUILD}-clang-cpp
   fi
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 {% set libcxx_major = 16 %}
 {% endif %}
 
-{% set build_number = 17 %}
+{% set build_number = 18 %}
 
 # pretend this variable is used, so that smithy populates the variant configs
 # [meson_release_flag]
@@ -59,7 +59,9 @@ outputs:
     test:
       commands:
         - {{ CBUILD }}-clang --version
+        - {{ CBUILD }}-clang-cpp --version
         - {{ macos_machine }}-clang --version
+        - {{ macos_machine }}-clang-cpp --version
 
   - name: clang_{{ cross_target_platform }}
     script: install-clang-scripts.sh
@@ -69,7 +71,9 @@ outputs:
     test:
       commands:
         - {{ CBUILD }}-clang --version
+        - {{ CBUILD }}-clang-cpp --version
         - {{ macos_machine }}-clang --version
+        - {{ macos_machine }}-clang-cpp --version
 
   - name: clangxx_impl_{{ cross_target_platform }}
     script: install-clangxx.sh
@@ -147,6 +151,7 @@ outputs:
     test:
       commands:
         - {{ macos_machine }}-clang --version
+        - {{ macos_machine }}-clang-cpp --version
         - {{ macos_machine }}-clang++ --version
     about:
       home: https://llvm.org


### PR DESCRIPTION
In https://github.com/conda-forge/openjdk-feedstock/pull/167, the build checks presence and functionality of the preprocessor. For linux, this is handled as `CPP=${CXX_FOR_BUILD//+/p}`, where `CXX_FOR_BUILD` generally uses the `$TRIPLE-<name>` style.

We're similarly setting
https://github.com/conda-forge/clang-compiler-activation-feedstock/blob/04e155656a0b3604bc2f0c2fc14484dbac7c3349/recipe/build.sh#L29-L30
here, but contrary to [`gcc_impl_linux-<arch>`](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Fgcc_impl_linux-64-14.1.0-h3c94d91_0.conda), we don't have a `$TRIPLE`-preprocessor for clang. Since the symlink structure is not the same for gcc & clang anyway (c.f. #118), add a symlink here for `$TRIPLE-clang-cpp`, like we do for `$TRIPLE-clang` already.