### PR TITLE
Reinstate libcxx version that matches compiler 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -26,7 +26,7 @@ channel_sources:
   - conda-forge
   - conda-forge
   - conda-forge
-  - conda-forge,conda-forge/label/llvm_rc
+  - conda-forge/label/llvm_rc,conda-forge
 channel_targets:
   - conda-forge main
   - conda-forge main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 # of the C++ stdlib; keep the variable in case this happens again
 {% set libcxx_major = major_ver %}
 
-{% set build_number = 18 %}
+{% set build_number = 19 %}
 
 # pretend this variable is used, so that smithy populates the variant configs
 # [meson_release_flag]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,12 +2,9 @@
 {% set version = "18.1.8" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
-# first version requiring `__osx >=10.13`; libcxx 18 still in progress
-{% if major_ver|int >= 17 %}
-{% set libcxx_major = 17 %}
-{% else %}
-{% set libcxx_major = 16 %}
-{% endif %}
+# in the past we've had to uncouple the compiler version from the version
+# of the C++ stdlib; keep the variable in case this happens again
+{% set libcxx_major = major_ver %}
 
 {% set build_number = 18 %}
 


### PR DESCRIPTION
We've finally caught back up after https://github.com/conda-forge/libcxx-feedstock/pull/155 got merged. 🙃 

C.f. list in #131 (resp. #113 before #128)