### PR TITLE
LLVM 19.1.0.rc1

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,28 +8,36 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      ? linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
-      : CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
+      ? linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0
+      : CONFIG: linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      ? linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
-      : CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      ? linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0
+      : CONFIG: linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      ? linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
-      : CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      ? linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
+      : CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      ? linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
-      : CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
+      ? linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      : CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      ? linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
-      : CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      ? linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      : CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      ? linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
-      : CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      ? linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
+      : CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      ? linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      : CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      ? linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      : CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,41 +8,53 @@ jobs:
     vmImage: macOS-12
   strategy:
     matrix:
-      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6:
-        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
+      ? osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0
+      : CONFIG: osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6:
-        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      ? osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0
+      : CONFIG: osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8:
-        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      ? osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
+      : CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
         UPLOAD_PACKAGES: 'True'
-      ? osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
-      : CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
+      ? osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      : CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
         UPLOAD_PACKAGES: 'True'
-      ? osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
-      : CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      ? osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      : CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
         UPLOAD_PACKAGES: 'True'
-      ? osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
-      : CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      ? osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
+      : CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
         UPLOAD_PACKAGES: 'True'
-      ? osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
-      : CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
+      ? osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      : CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
         UPLOAD_PACKAGES: 'True'
-      ? osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
-      : CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      ? osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      : CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
         UPLOAD_PACKAGES: 'True'
-      ? osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
-      : CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      ? osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0
+      : CONFIG: osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0
         UPLOAD_PACKAGES: 'True'
-      ? osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
-      : CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
+      ? osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0
+      : CONFIG: osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0
         UPLOAD_PACKAGES: 'True'
-      ? osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
-      : CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      ? osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
+      : CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
         UPLOAD_PACKAGES: 'True'
-      ? osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
-      : CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      ? osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      : CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+        UPLOAD_PACKAGES: 'True'
+      ? osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      : CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+        UPLOAD_PACKAGES: 'True'
+      ? osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
+      : CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6
+        UPLOAD_PACKAGES: 'True'
+      ? osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+      : CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6
+        UPLOAD_PACKAGES: 'True'
+      ? osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
+      : CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -1,31 +1,33 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
-- osx-arm64
+- osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 18.1.8
+- 19.1.0
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +37,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -7,7 +7,7 @@ MACOSX_DEPLOYMENT_TARGET:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/llvm_rc,conda-forge
+- conda-forge,conda-forge/label/llvm_rc
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:

--- a/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -7,7 +7,7 @@ MACOSX_DEPLOYMENT_TARGET:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/llvm_rc,conda-forge
+- conda-forge,conda-forge/label/llvm_rc
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:

--- a/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -1,31 +1,33 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
-- osx-64
+- osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 17.0.6
+- 19.1.0
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +37,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
@@ -1,0 +1,41 @@
+CBUILD:
+- x86_64-conda-linux-gnu
+FINAL_PYTHON_SYSCONFIGDATA_NAME:
+- _sysconfigdata_x86_64_apple_darwin13_4_0
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cross_target_platform:
+- osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+macos_machine:
+- x86_64-apple-darwin13.4.0
+meson_cpu_family:
+- x86_64
+meson_release_flag:
+- --buildtype release
+target_platform:
+- linux-64
+uname_kernel_release:
+- 13.4.0
+uname_machine:
+- x86_64
+version:
+- 16.0.6
+zip_keys:
+- - cross_target_platform
+  - macos_machine
+  - meson_cpu_family
+  - uname_machine
+  - uname_kernel_release
+  - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
@@ -1,0 +1,41 @@
+CBUILD:
+- x86_64-conda-linux-gnu
+FINAL_PYTHON_SYSCONFIGDATA_NAME:
+- _sysconfigdata_x86_64_apple_darwin13_4_0
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cross_target_platform:
+- osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+macos_machine:
+- x86_64-apple-darwin13.4.0
+meson_cpu_family:
+- x86_64
+meson_release_flag:
+- -Dbuildtype=release
+target_platform:
+- linux-64
+uname_kernel_release:
+- 13.4.0
+uname_machine:
+- x86_64
+version:
+- 17.0.6
+zip_keys:
+- - cross_target_platform
+  - macos_machine
+  - meson_cpu_family
+  - uname_machine
+  - uname_kernel_release
+  - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
@@ -1,17 +1,19 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+- '10.9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
@@ -19,13 +21,13 @@ meson_cpu_family:
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- osx-64
+- linux-64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 17.0.6
+- 18.1.8
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +37,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
@@ -1,31 +1,33 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+- '10.9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
 - aarch64
 meson_release_flag:
-- -Dbuildtype=release
+- --buildtype release
 target_platform:
-- osx-64
+- linux-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 18.1.8
+- 16.0.6
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +37,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
@@ -1,17 +1,19 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
@@ -19,7 +21,7 @@ meson_cpu_family:
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
@@ -35,3 +37,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
@@ -1,0 +1,41 @@
+CBUILD:
+- x86_64-conda-linux-gnu
+FINAL_PYTHON_SYSCONFIGDATA_NAME:
+- _sysconfigdata_arm64_apple_darwin20_0_0
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cross_target_platform:
+- osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+macos_machine:
+- arm64-apple-darwin20.0.0
+meson_cpu_family:
+- aarch64
+meson_release_flag:
+- -Dbuildtype=release
+target_platform:
+- linux-64
+uname_kernel_release:
+- 20.0.0
+uname_machine:
+- arm64
+version:
+- 18.1.8
+zip_keys:
+- - cross_target_platform
+  - macos_machine
+  - meson_cpu_family
+  - uname_machine
+  - uname_kernel_release
+  - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -1,31 +1,31 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
-- osx-arm64
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 meson_release_flag:
-- --buildtype release
+- -Dbuildtype=release
 target_platform:
-- osx-arm64
+- osx-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 16.0.6
+- 19.1.0
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -7,7 +7,7 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '10.13'
 channel_sources:
-- conda-forge/label/llvm_rc,conda-forge
+- conda-forge,conda-forge/label/llvm_rc
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:

--- a/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -1,0 +1,39 @@
+CBUILD:
+- x86_64-apple-darwin13.4.0
+FINAL_PYTHON_SYSCONFIGDATA_NAME:
+- _sysconfigdata_arm64_apple_darwin20_0_0
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+channel_sources:
+- conda-forge/label/llvm_rc,conda-forge
+channel_targets:
+- conda-forge llvm_rc
+cross_target_platform:
+- osx-arm64
+macos_machine:
+- arm64-apple-darwin20.0.0
+meson_cpu_family:
+- aarch64
+meson_release_flag:
+- -Dbuildtype=release
+target_platform:
+- osx-64
+uname_kernel_release:
+- 20.0.0
+uname_machine:
+- arm64
+version:
+- 19.1.0
+zip_keys:
+- - cross_target_platform
+  - macos_machine
+  - meson_cpu_family
+  - uname_machine
+  - uname_kernel_release
+  - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -7,7 +7,7 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '10.13'
 channel_sources:
-- conda-forge/label/llvm_rc,conda-forge
+- conda-forge,conda-forge/label/llvm_rc
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
@@ -1,31 +1,29 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos7
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 meson_release_flag:
 - --buildtype release
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
 - 16.0.6
 zip_keys:
@@ -37,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
@@ -1,0 +1,39 @@
+CBUILD:
+- x86_64-apple-darwin13.4.0
+FINAL_PYTHON_SYSCONFIGDATA_NAME:
+- _sysconfigdata_x86_64_apple_darwin13_4_0
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cross_target_platform:
+- osx-64
+macos_machine:
+- x86_64-apple-darwin13.4.0
+meson_cpu_family:
+- x86_64
+meson_release_flag:
+- -Dbuildtype=release
+target_platform:
+- osx-64
+uname_kernel_release:
+- 13.4.0
+uname_machine:
+- x86_64
+version:
+- 17.0.6
+zip_keys:
+- - cross_target_platform
+  - macos_machine
+  - meson_cpu_family
+  - uname_machine
+  - uname_kernel_release
+  - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
@@ -1,31 +1,29 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos7
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
 - 18.1.8
 zip_keys:
@@ -37,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
@@ -1,7 +1,7 @@
 CBUILD:
 - x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
@@ -11,21 +11,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 meson_release_flag:
-- -Dbuildtype=release
+- --buildtype release
 target_platform:
 - osx-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 18.1.8
+- 16.0.6
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
@@ -1,31 +1,31 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-macos_machine:
-- x86_64-apple-darwin13.4.0
-meson_cpu_family:
-- x86_64
-meson_release_flag:
-- --buildtype release
-target_platform:
 - osx-arm64
+macos_machine:
+- arm64-apple-darwin20.0.0
+meson_cpu_family:
+- aarch64
+meson_release_flag:
+- -Dbuildtype=release
+target_platform:
+- osx-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 16.0.6
+- 17.0.6
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
@@ -1,31 +1,29 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos7
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- osx-arm64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
 - 18.1.8
 zip_keys:
@@ -37,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -7,7 +7,7 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '11.0'
 channel_sources:
-- conda-forge/label/llvm_rc,conda-forge
+- conda-forge,conda-forge/label/llvm_rc
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -1,33 +1,31 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos7
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
 - osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
 - x86_64
 meson_release_flag:
-- --buildtype release
+- -Dbuildtype=release
 target_platform:
-- linux-64
+- osx-arm64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 16.0.6
+- 19.1.0
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -37,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -7,7 +7,7 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '11.0'
 channel_sources:
-- conda-forge/label/llvm_rc,conda-forge
+- conda-forge,conda-forge/label/llvm_rc
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.yaml
@@ -1,19 +1,17 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos7
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
 - osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
@@ -21,13 +19,13 @@ meson_cpu_family:
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- linux-64
+- osx-arm64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 17.0.6
+- 19.1.0
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -37,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
@@ -1,33 +1,31 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos7
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
 - x86_64
 meson_release_flag:
-- -Dbuildtype=release
+- --buildtype release
 target_platform:
-- linux-64
+- osx-arm64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 17.0.6
+- 16.0.6
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -37,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
@@ -1,31 +1,31 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-macos_machine:
-- arm64-apple-darwin20.0.0
-meson_cpu_family:
-- aarch64
-meson_release_flag:
-- --buildtype release
-target_platform:
 - osx-64
+macos_machine:
+- x86_64-apple-darwin13.4.0
+meson_cpu_family:
+- x86_64
+meson_release_flag:
+- -Dbuildtype=release
+target_platform:
+- osx-arm64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 16.0.6
+- 17.0.6
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
@@ -1,11 +1,11 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,15 +17,15 @@ macos_machine:
 meson_cpu_family:
 - x86_64
 meson_release_flag:
-- --buildtype release
+- -Dbuildtype=release
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 16.0.6
+- 18.1.8
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6.yaml
@@ -1,0 +1,39 @@
+CBUILD:
+- arm64-apple-darwin20.0.0
+FINAL_PYTHON_SYSCONFIGDATA_NAME:
+- _sysconfigdata_arm64_apple_darwin20_0_0
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cross_target_platform:
+- osx-arm64
+macos_machine:
+- arm64-apple-darwin20.0.0
+meson_cpu_family:
+- aarch64
+meson_release_flag:
+- --buildtype release
+target_platform:
+- osx-arm64
+uname_kernel_release:
+- 20.0.0
+uname_machine:
+- arm64
+version:
+- 16.0.6
+zip_keys:
+- - cross_target_platform
+  - macos_machine
+  - meson_cpu_family
+  - uname_machine
+  - uname_kernel_release
+  - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6.yaml
@@ -1,7 +1,7 @@
 CBUILD:
 - arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
@@ -11,21 +11,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
 - osx-arm64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 18.1.8
+- 17.0.6
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8.yaml
@@ -1,11 +1,11 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,13 +19,13 @@ meson_cpu_family:
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 17.0.6
+- 18.1.8
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -35,3 +35,5 @@ zip_keys:
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
 - - version
   - meson_release_flag
+  - channel_sources
+  - channel_targets

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -72,7 +72,6 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
-
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Package license: BSD-3-Clause
 
 Summary: clang compilers for conda-build 3
 
-About clang_bootstrap_osx-64
-----------------------------
+About clang_bootstrap_osx-arm64
+-------------------------------
 
 Home: https://llvm.org
 
@@ -22,8 +22,8 @@ Package license: Apache-2.0
 
 Summary: clang compiler components in one package for bootstrapping clang
 
-About clang_bootstrap_osx-arm64
--------------------------------
+About clang_bootstrap_osx-64
+----------------------------
 
 Home: https://llvm.org
 
@@ -49,129 +49,171 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6</td>
+              <td>linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
+              <td>linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
+              <td>osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6</td>
+              <td>osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
+              <td>osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
+              <td>osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag--buildtype_releaseversion16.0.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion17.0.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8" alt="variant">
                 </a>
               </td>
             </tr>
@@ -201,14 +243,14 @@ Current release info
 Installing clang-compiler-activation
 ====================================
 
-Installing `clang-compiler-activation` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `clang-compiler-activation` from the `conda-forge/label/llvm_rc` channel can be achieved by adding `conda-forge/label/llvm_rc` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels conda-forge/label/llvm_rc
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `clang_bootstrap_osx-64, clang_bootstrap_osx-arm64, clang_impl_osx-64, clang_impl_osx-arm64, clang_osx-64, clang_osx-arm64, clangxx_impl_osx-64, clangxx_impl_osx-arm64, clangxx_osx-64, clangxx_osx-arm64` can be installed with `conda`:
+Once the `conda-forge/label/llvm_rc` channel has been enabled, `clang_bootstrap_osx-64, clang_bootstrap_osx-arm64, clang_impl_osx-64, clang_impl_osx-arm64, clang_osx-64, clang_osx-arm64, clangxx_impl_osx-64, clangxx_impl_osx-arm64, clangxx_osx-64, clangxx_osx-arm64` can be installed with `conda`:
 
 ```
 conda install clang_bootstrap_osx-64 clang_bootstrap_osx-arm64 clang_impl_osx-64 clang_impl_osx-arm64 clang_osx-64 clang_osx-arm64 clangxx_impl_osx-64 clangxx_impl_osx-arm64 clangxx_osx-64 clangxx_osx-arm64
@@ -223,26 +265,26 @@ mamba install clang_bootstrap_osx-64 clang_bootstrap_osx-arm64 clang_impl_osx-64
 It is possible to list all of the versions of `clang_bootstrap_osx-64` available on your platform with `conda`:
 
 ```
-conda search clang_bootstrap_osx-64 --channel conda-forge
+conda search clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 ```
 
 or with `mamba`:
 
 ```
-mamba search clang_bootstrap_osx-64 --channel conda-forge
+mamba search clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search clang_bootstrap_osx-64 --channel conda-forge
+mamba repoquery search clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 
 # List packages depending on `clang_bootstrap_osx-64`:
-mamba repoquery whoneeds clang_bootstrap_osx-64 --channel conda-forge
+mamba repoquery whoneeds clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 
 # List dependencies of `clang_bootstrap_osx-64`:
-mamba repoquery depends clang_bootstrap_osx-64 --channel conda-forge
+mamba repoquery depends clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 ```
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,12 +12,26 @@ version:
   - 16.0.6
   - 17.0.6
   - 18.1.8
+  - 19.1.0
 
 # switch over release flag style cleanly across compiler versions, see #112
 meson_release_flag:
   - "--buildtype release"
   - "-Dbuildtype=release"
   - "-Dbuildtype=release"
+  - "-Dbuildtype=release"
+
+# zip to avoid using rc-builds for already-released-in-conda-forge LLVM versions
+channel_sources:
+  - conda-forge
+  - conda-forge
+  - conda-forge
+  - conda-forge/label/llvm_rc,conda-forge
+channel_targets:
+  - conda-forge main
+  - conda-forge main
+  - conda-forge main
+  - conda-forge llvm_rc
 
 # everything below is zipped
 cross_target_platform:
@@ -50,3 +64,5 @@ zip_keys:
   -
     - version
     - meson_release_flag
+    - channel_sources
+    - channel_targets

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -26,7 +26,7 @@ channel_sources:
   - conda-forge
   - conda-forge
   - conda-forge
-  - conda-forge/label/llvm_rc,conda-forge
+  - conda-forge,conda-forge/label/llvm_rc
 channel_targets:
   - conda-forge main
   - conda-forge main


### PR DESCRIPTION
Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency):

* [x] https://github.com/conda-forge/llvmdev-feedstock/pull/280
  * [x] https://github.com/conda-forge/clangdev-feedstock/pull/304
    * [x] https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/73 (only needs major version)
    * [x] https://github.com/conda-forge/compiler-rt-feedstock/pull/115
      * [x] https://github.com/conda-forge/openmp-feedstock/pull/137
    * [x] https://github.com/conda-forge/libcxx-feedstock/pull/170 (still using libcxx 17 here for now, see #134)
  * [x] https://github.com/conda-forge/lld-feedstock/pull/101

Related feedstocks for LLVM 19.1.0 support more generally:
* [ ] https://github.com/conda-forge/clang-win-activation-feedstock (needs this PR)
* [ ] https://github.com/conda-forge/ctng-compiler-activation-feedstock (only needs major version)
* [x] https://github.com/conda-forge/flang-feedstock/pull/60 (needs mlir, compiler-rt)
* [ ] https://github.com/conda-forge/libcxx-testing-feedstock (only needs major version)
* [ ] https://github.com/conda-forge/lldb-feedstock (needs this PR)
* [x] https://github.com/conda-forge/mlir-feedstock/pull/76 (needs llvmdev)
* [ ] https://github.com/conda-forge/mlir-python-bindings-feedstock (needs llvmdev & mlir)
* [ ] https://github.com/conda-forge/r_clang_activation-feedstock (needs clangdev)