### PR TITLE
LLVM 19.1.0.rc3

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      ? linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
-      : CONFIG: linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
+      ? linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
+      : CONFIG: linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      ? linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
-      : CONFIG: linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
+      ? linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
+      : CONFIG: linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       ? linux_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,11 @@ jobs:
     vmImage: macOS-12
   strategy:
     matrix:
-      ? osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
-      : CONFIG: osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
+      ? osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
+      : CONFIG: osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
         UPLOAD_PACKAGES: 'True'
-      ? osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
-      : CONFIG: osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
+      ? osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
+      : CONFIG: osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
         UPLOAD_PACKAGES: 'True'
       ? osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
       : CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
@@ -32,11 +32,11 @@ jobs:
       ? osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
       : CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion18.1.8
         UPLOAD_PACKAGES: 'True'
-      ? osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
-      : CONFIG: osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
+      ? osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
+      : CONFIG: osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
         UPLOAD_PACKAGES: 'True'
-      ? osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
-      : CONFIG: osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2
+      ? osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
+      : CONFIG: osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3
         UPLOAD_PACKAGES: 'True'
       ? osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6
       : CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag--buildtype_releaseversion16.0.6

--- a/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
@@ -1,31 +1,33 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,conda-forge/label/llvm_rc
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:
-- osx-arm64
+- osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 19.1.0.rc2
+- 19.1.0.rc3
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
@@ -1,31 +1,33 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,conda-forge/label/llvm_rc
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:
-- osx-64
+- osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 19.1.0.rc2
+- 19.1.0.rc3
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
@@ -1,31 +1,31 @@
 CBUILD:
 - x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
 channel_sources:
-- conda-forge,conda-forge/label/llvm_rc
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:
-- osx-arm64
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
 - osx-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 19.1.0.rc2
+- 19.1.0.rc3
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
@@ -1,19 +1,17 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos7
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
-- conda-forge,conda-forge/label/llvm_rc
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:
 - osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
@@ -21,13 +19,13 @@ meson_cpu_family:
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 19.1.0.rc2
+- 19.1.0.rc3
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
@@ -1,19 +1,17 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- cos7
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 channel_sources:
-- conda-forge,conda-forge/label/llvm_rc
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:
 - osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
@@ -21,13 +19,13 @@ meson_cpu_family:
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- linux-64
+- osx-arm64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 19.1.0.rc2
+- 19.1.0.rc3
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3.yaml
@@ -1,31 +1,31 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
-- conda-forge,conda-forge/label/llvm_rc
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
 - conda-forge llvm_rc
 cross_target_platform:
-- osx-64
+- osx-arm64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 meson_release_flag:
 - -Dbuildtype=release
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 19.1.0.rc2
+- 19.1.0.rc3
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Package license: BSD-3-Clause
 
 Summary: clang compilers for conda-build 3
 
-About clang_bootstrap_osx-64
-----------------------------
+About clang_bootstrap_osx-arm64
+-------------------------------
 
 Home: https://llvm.org
 
@@ -22,8 +22,8 @@ Package license: Apache-2.0
 
 Summary: clang compiler components in one package for bootstrapping clang
 
-About clang_bootstrap_osx-arm64
--------------------------------
+About clang_bootstrap_osx-64
+----------------------------
 
 Home: https://llvm.org
 
@@ -49,17 +49,17 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2</td>
+              <td>linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2</td>
+              <td>linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -105,17 +105,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2</td>
+              <td>osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2</td>
+              <td>osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -161,17 +161,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2</td>
+              <td>osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2</td>
+              <td>osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0meson_release_flag-Dbuildtype=releaseversion19.1.0.rc3" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,7 +12,7 @@ version:
   - 16.0.6
   - 17.0.6
   - 18.1.8
-  - 19.1.0.rc2
+  - 19.1.0.rc3
 
 # switch over release flag style cleanly across compiler versions, see #112
 meson_release_flag:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,6 +6,10 @@
 # of the C++ stdlib; keep the variable in case this happens again
 {% set libcxx_major = major_ver %}
 
+{% if CBUILD is not defined %}
+{% set CBUILD = "dummy" %}
+{% endif %}
+
 {% set build_number = 19 %}
 
 # pretend this variable is used, so that smithy populates the variant configs


### PR DESCRIPTION
Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency):

* [x] https://github.com/conda-forge/llvmdev-feedstock/pull/284
  * [x] https://github.com/conda-forge/clangdev-feedstock/pull/308
    * [x] https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/73 (only needs major version)
    * [x] https://github.com/conda-forge/compiler-rt-feedstock/pull/118
      * [x] https://github.com/conda-forge/openmp-feedstock/pull/142
    * [x] https://github.com/conda-forge/libcxx-feedstock/pull/182
  * [x] https://github.com/conda-forge/lld-feedstock/pull/103

Related feedstocks for LLVM 19.1.0 support more generally:
* [ ] https://github.com/conda-forge/clang-win-activation-feedstock (needs this PR)
* [ ] https://github.com/conda-forge/ctng-compiler-activation-feedstock (only needs major version)
* [ ] https://github.com/conda-forge/flang-feedstock/pull/70 (needs mlir, compiler-rt)
* [ ] https://github.com/conda-forge/libcxx-testing-feedstock (only needs major version)
* [ ] https://github.com/conda-forge/lldb-feedstock (needs this PR)
* [x] https://github.com/conda-forge/mlir-feedstock/pull/79 (needs llvmdev)
* [ ] https://github.com/conda-forge/mlir-python-bindings-feedstock (needs llvmdev & mlir)
* [ ] https://github.com/conda-forge/r_clang_activation-feedstock (needs clangdev)