### PR TITLE
set needs_exe_wrapper for cross-compile

### DIFF
--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -160,6 +160,8 @@ if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
   echo "[binaries]" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "cmake = '${CONDA_PREFIX}/bin/cmake'" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "pkg-config = '${CONDA_PREFIX}/bin/pkg-config'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "[properties]" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "needs_exe_wrapper = true" >> ${CONDA_PREFIX}/meson_cross_file.txt
 fi
 
 _tc_activation \

--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -160,6 +160,8 @@ if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
   echo "[binaries]" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "cmake = '${CONDA_PREFIX}/bin/cmake'" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "pkg-config = '${CONDA_PREFIX}/bin/pkg-config'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  # meson guesses whether it can run binaries in cross-compilation based on some heuristics,
+  # and those can be wrong; see https://mesonbuild.com/Cross-compilation.html#properties
   echo "[properties]" >> ${CONDA_PREFIX}/meson_cross_file.txt
   echo "needs_exe_wrapper = true" >> ${CONDA_PREFIX}/meson_cross_file.txt
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 # of the C++ stdlib; keep the variable in case this happens again
 {% set libcxx_major = major_ver %}
 
-{% set build_number = 19 %}
+{% set build_number = 20 %}
 
 # pretend this variable is used, so that smithy populates the variant configs
 # [meson_release_flag]


### PR DESCRIPTION
since we are using crossenv, meson thinks we can run the executables

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
