### PR TITLE
LLVM v19.1.7

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,8 +16,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.8
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6:
-        CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6
+      linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7:
+        CONFIG: linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6:
@@ -28,8 +28,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.8
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6:
-        CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6
+      linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7:
+        CONFIG: linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,8 +14,8 @@ jobs:
       osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.8:
         CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.8
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6:
-        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6
+      osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7:
+        CONFIG: osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7
         UPLOAD_PACKAGES: 'True'
       osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6:
         CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6
@@ -23,8 +23,8 @@ jobs:
       osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.8:
         CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.8
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6:
-        CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6
+      osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7:
+        CONFIG: osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7
         UPLOAD_PACKAGES: 'True'
       osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version17.0.6
@@ -32,8 +32,8 @@ jobs:
       osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.8:
         CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version18.1.8
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6:
-        CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6
+      osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7:
+        CONFIG: osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7
         UPLOAD_PACKAGES: 'True'
       osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6:
         CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version17.0.6
@@ -41,8 +41,8 @@ jobs:
       osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.8:
         CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version18.1.8
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6
+      osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7:
+        CONFIG: osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7.yaml
@@ -1,29 +1,31 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
 - x86_64
 target_platform:
-- osx-64
+- linux-64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 19.1.6
+- 19.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7.yaml
@@ -25,7 +25,7 @@ uname_kernel_release:
 uname_machine:
 - arm64
 version:
-- 19.1.6
+- 19.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7.yaml
@@ -1,11 +1,11 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,13 +17,13 @@ macos_machine:
 meson_cpu_family:
 - x86_64
 target_platform:
-- osx-arm64
+- osx-64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 19.1.6
+- 19.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7.yaml
@@ -1,31 +1,29 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- osx-arm64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 19.1.6
+- 19.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7.yaml
@@ -1,29 +1,29 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-macos_machine:
-- arm64-apple-darwin20.0.0
-meson_cpu_family:
-- aarch64
-target_platform:
 - osx-64
+macos_machine:
+- x86_64-apple-darwin13.4.0
+meson_cpu_family:
+- x86_64
+target_platform:
+- osx-arm64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 19.1.6
+- 19.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7.yaml
@@ -23,7 +23,7 @@ uname_kernel_release:
 uname_machine:
 - arm64
 version:
-- 19.1.6
+- 19.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Package license: BSD-3-Clause
 
 Summary: clang compilers for conda-build 3
 
-About clang_bootstrap_osx-arm64
--------------------------------
+About clang_bootstrap_osx-64
+----------------------------
 
 Home: https://llvm.org
 
@@ -22,8 +22,8 @@ Package license: Apache-2.0
 
 Summary: clang compiler components in one package for bootstrapping clang
 
-About clang_bootstrap_osx-64
-----------------------------
+About clang_bootstrap_osx-arm64
+-------------------------------
 
 Home: https://llvm.org
 
@@ -63,10 +63,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6</td>
+              <td>linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -84,10 +84,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6</td>
+              <td>linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -105,10 +105,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6</td>
+              <td>osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -126,10 +126,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6</td>
+              <td>osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -147,10 +147,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6</td>
+              <td>osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64macos_machinex86_64-apple-darwin13.4.0version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -168,10 +168,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6</td>
+              <td>osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64macos_machinearm64-apple-darwin20.0.0version19.1.7" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:  # [linux]
 version:
   - 17.0.6
   - 18.1.8
-  - 19.1.6
+  - 19.1.7
 
 # everything below is zipped
 cross_target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% if version is not defined %}
-{% set version = "19.1.6" %}
+{% set version = "19.1.7" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 # in the past we've had to uncouple the compiler version from the version


### PR DESCRIPTION
Github broke the mermaid rendering, so it's back to list-only
### List form

Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency):

* [x] https://github.com/conda-forge/libcxx-feedstock/pull/213
* [x] https://github.com/conda-forge/llvmdev-feedstock/pull/307
  * [x] https://github.com/conda-forge/clangdev-feedstock/pull/334 (also needs libcxx)
    * [x] https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/78 (major-only)
    * [x] https://github.com/conda-forge/compiler-rt-feedstock/pull/133
      * [ ] https://github.com/conda-forge/openmp-feedstock/pull/163
  * [x] https://github.com/conda-forge/lld-feedstock/pull/117

Clang 19.1 for other platforms (major-only):
* [x] https://github.com/conda-forge/clang-win-activation-feedstock/pull/44
* [x] https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/131
* [x] https://github.com/conda-forge/r_clang_activation-feedstock/pull/8

Other LLVM-related feedstocks:
* [ ] https://github.com/conda-forge/flang-feedstock/pull/84 (needs compiler-rt, mlir)
* [ ] https://github.com/conda-forge/flang-activation-feedstock/pull/17 (needs flang, lld)
* [x] https://github.com/conda-forge/libcxx-testing-feedstock/pull/15 (major-only)
* [ ] https://github.com/conda-forge/lldb-feedstock/pull/80 (needs this PR)
* [x] https://github.com/conda-forge/mlir-feedstock/pull/90 (needs llvmdev)
* [ ] https://github.com/conda-forge/mlir-python-bindings-feedstock/pull/46 (needs this PR)