### PR TITLE
LLVM v20.1.6

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,8 +16,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformosx-64version19.1.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-64version20.1.5:
-        CONFIG: linux_64_cross_target_platformosx-64version20.1.5
+      linux_64_cross_target_platformosx-64version20.1.6:
+        CONFIG: linux_64_cross_target_platformosx-64version20.1.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cross_target_platformosx-arm64version18.1.8:
@@ -28,8 +28,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformosx-arm64version19.1.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-arm64version20.1.5:
-        CONFIG: linux_64_cross_target_platformosx-arm64version20.1.5
+      linux_64_cross_target_platformosx-arm64version20.1.6:
+        CONFIG: linux_64_cross_target_platformosx-arm64version20.1.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,8 +14,8 @@ jobs:
       osx_64_cross_target_platformosx-64version19.1.7:
         CONFIG: osx_64_cross_target_platformosx-64version19.1.7
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64version20.1.5:
-        CONFIG: osx_64_cross_target_platformosx-64version20.1.5
+      osx_64_cross_target_platformosx-64version20.1.6:
+        CONFIG: osx_64_cross_target_platformosx-64version20.1.6
         UPLOAD_PACKAGES: 'True'
       osx_64_cross_target_platformosx-arm64version18.1.8:
         CONFIG: osx_64_cross_target_platformosx-arm64version18.1.8
@@ -23,8 +23,8 @@ jobs:
       osx_64_cross_target_platformosx-arm64version19.1.7:
         CONFIG: osx_64_cross_target_platformosx-arm64version19.1.7
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64version20.1.5:
-        CONFIG: osx_64_cross_target_platformosx-arm64version20.1.5
+      osx_64_cross_target_platformosx-arm64version20.1.6:
+        CONFIG: osx_64_cross_target_platformosx-arm64version20.1.6
         UPLOAD_PACKAGES: 'True'
       osx_arm64_cross_target_platformosx-64version18.1.8:
         CONFIG: osx_arm64_cross_target_platformosx-64version18.1.8
@@ -32,8 +32,8 @@ jobs:
       osx_arm64_cross_target_platformosx-64version19.1.7:
         CONFIG: osx_arm64_cross_target_platformosx-64version19.1.7
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64version20.1.5:
-        CONFIG: osx_arm64_cross_target_platformosx-64version20.1.5
+      osx_arm64_cross_target_platformosx-64version20.1.6:
+        CONFIG: osx_arm64_cross_target_platformosx-64version20.1.6
         UPLOAD_PACKAGES: 'True'
       osx_arm64_cross_target_platformosx-arm64version18.1.8:
         CONFIG: osx_arm64_cross_target_platformosx-arm64version18.1.8
@@ -41,8 +41,8 @@ jobs:
       osx_arm64_cross_target_platformosx-arm64version19.1.7:
         CONFIG: osx_arm64_cross_target_platformosx-arm64version19.1.7
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64version20.1.5:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64version20.1.5
+      osx_arm64_cross_target_platformosx-arm64version20.1.6:
+        CONFIG: osx_arm64_cross_target_platformosx-arm64version20.1.6
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_cross_target_platformosx-64version20.1.6.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64version20.1.6.yaml
@@ -1,29 +1,31 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
 - x86_64
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 20.1.5
+- 20.1.6
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/linux_64_cross_target_platformosx-arm64version20.1.6.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64version20.1.6.yaml
@@ -1,29 +1,31 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
 - aarch64
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 20.1.5
+- 20.1.6
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-64version20.1.6.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64version20.1.6.yaml
@@ -1,7 +1,7 @@
 CBUILD:
 - x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
@@ -11,19 +11,19 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 target_platform:
 - osx-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 20.1.5
+- 20.1.6
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-arm64version20.1.6.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64version20.1.6.yaml
@@ -1,31 +1,29 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
 - aarch64
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 20.1.5
+- 20.1.6
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-64version20.1.6.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64version20.1.6.yaml
@@ -1,31 +1,29 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
 - x86_64
 target_platform:
-- linux-64
+- osx-arm64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 20.1.5
+- 20.1.6
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64version20.1.6.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64version20.1.6.yaml
@@ -1,29 +1,29 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 20.1.5
+- 20.1.6
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64version20.1.5</td>
+              <td>linux_64_cross_target_platformosx-64version20.1.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64version20.1.5" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64version20.1.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -84,10 +84,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64version20.1.5</td>
+              <td>linux_64_cross_target_platformosx-arm64version20.1.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64version20.1.5" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64version20.1.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -105,10 +105,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64version20.1.5</td>
+              <td>osx_64_cross_target_platformosx-64version20.1.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64version20.1.5" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64version20.1.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -126,10 +126,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64version20.1.5</td>
+              <td>osx_64_cross_target_platformosx-arm64version20.1.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64version20.1.5" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64version20.1.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -147,10 +147,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64version20.1.5</td>
+              <td>osx_arm64_cross_target_platformosx-64version20.1.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64version20.1.5" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64version20.1.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -168,10 +168,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64version20.1.5</td>
+              <td>osx_arm64_cross_target_platformosx-arm64version20.1.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64version20.1.5" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64version20.1.6" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:  # [linux]
 version:
   - 18.1.8
   - 19.1.7
-  - 20.1.5
+  - 20.1.6
 
 # everything below is zipped
 cross_target_platform:

--- a/recipe/install-clang_impl.sh
+++ b/recipe/install-clang_impl.sh
@@ -7,9 +7,7 @@ CHOST=${macos_machine}
 pushd "${PREFIX}"/bin
   ln -s clang ${CHOST}-clang
   ln -s clang-cpp ${CHOST}-clang-cpp
-  if [[ "${CBUILD}" != ${CHOST} ]] && [[ "${target_platform}" != linux-* || ( ${version} != "17.0.6" && ${version} != "18.1.8") ]]; then
-    # before v19.1.1, `clang` on linux already had this symlink, see
-    # https://github.com/conda-forge/clangdev-feedstock/pull/322
+  if [[ "${CBUILD}" != ${CHOST} ]]; then
     ln -s clang ${CBUILD}-clang
     ln -s clang-cpp ${CBUILD}-clang-cpp
   fi

--- a/recipe/install-clangxx_impl.sh
+++ b/recipe/install-clangxx_impl.sh
@@ -7,9 +7,7 @@ echo CHOST is ${CHOST}
 
 pushd "${PREFIX}"/bin
   ln -s clang++ ${CHOST}-clang++
-  if [[ "${CBUILD}" != ${CHOST} ]] && [[ "${target_platform}" != linux-* || ( ${version} != "17.0.6" && ${version} != "18.1.8") ]]; then
-    # before v19.1.1, `clangxx` on linux already had this symlink, see
-    # https://github.com/conda-forge/clangdev-feedstock/pull/322
+  if [[ "${CBUILD}" != ${CHOST} ]]; then
     ln -s clang++ ${CBUILD}-clang++
   fi
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 # of the C++ stdlib; keep the variable in case this happens again
 {% set libcxx_major = major_ver %}
 
-{% set build_number = 24 %}
+{% set build_number = 25 %}
 
 package:
   name: clang-compiler-activation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% if version is not defined %}
-{% set version = "20.1.5" %}
+{% set version = "20.1.6" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 # in the past we've had to uncouple the compiler version from the version


### PR DESCRIPTION
The [readdition](https://github.com/llvm/llvm-project/commit/be087ab35970dffe3e473b5a10266ed356261746) of `_LIBCPP_DISABLE_AVAILABILITY` (c.f. #153) finally landed after missing a couple of patch releases... I've got my fingers crossed that this might potentially fix https://github.com/conda-forge/libcxx-feedstock/issues/220 and thus also lldb and mlir-python 🤞 

### List form

Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency):

* [x] https://github.com/conda-forge/libcxx-feedstock/pull/229
* [x] https://github.com/conda-forge/llvmdev-feedstock/pull/326
  * [x] https://github.com/conda-forge/clangdev-feedstock/pull/359 (also needs libcxx)
    * [x] https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/83 (major-only)
    * [x] https://github.com/conda-forge/compiler-rt-feedstock/pull/143
      * [x] https://github.com/conda-forge/openmp-feedstock/pull/176
  * [x] https://github.com/conda-forge/lld-feedstock/pull/126

Other LLVM-related feedstocks:
* [ ] https://github.com/conda-forge/flang-feedstock/pull/104 (needs compiler-rt, mlir)
* [ ] https://github.com/conda-forge/flang-activation-feedstock/pull/28 (needs flang, lld)
* [ ] https://github.com/conda-forge/lldb-feedstock/pull/87 (needs this PR)
* [x] https://github.com/conda-forge/mlir-feedstock/pull/99 (needs llvmdev)
* [ ] https://github.com/conda-forge/mlir-python-bindings-feedstock/pull/53 (needs this PR)