### PR TITLE
LLVM v21.1.0.rc1

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,28 +8,28 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_cross_target_platformosx-64version18.1.8:
-        CONFIG: linux_64_cross_target_platformosx-64version18.1.8
+      linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1:
+        CONFIG: linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-64version19.1.7:
-        CONFIG: linux_64_cross_target_platformosx-64version19.1.7
+      linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1:
+        CONFIG: linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-64version20.1.8:
-        CONFIG: linux_64_cross_target_platformosx-64version20.1.8
+      linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7:
+        CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-arm64version18.1.8:
-        CONFIG: linux_64_cross_target_platformosx-arm64version18.1.8
+      linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8:
+        CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-arm64version19.1.7:
-        CONFIG: linux_64_cross_target_platformosx-arm64version19.1.7
+      linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7:
+        CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-arm64version20.1.8:
-        CONFIG: linux_64_cross_target_platformosx-arm64version20.1.8
+      linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8:
+        CONFIG: linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,41 +8,41 @@ jobs:
     vmImage: macOS-13
   strategy:
     matrix:
-      osx_64_cross_target_platformosx-64version18.1.8:
-        CONFIG: osx_64_cross_target_platformosx-64version18.1.8
+      osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1:
+        CONFIG: osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64version19.1.7:
-        CONFIG: osx_64_cross_target_platformosx-64version19.1.7
+      osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1:
+        CONFIG: osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64version20.1.8:
-        CONFIG: osx_64_cross_target_platformosx-64version20.1.8
+      osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7:
+        CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64version18.1.8:
-        CONFIG: osx_64_cross_target_platformosx-arm64version18.1.8
+      osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8:
+        CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64version19.1.7:
-        CONFIG: osx_64_cross_target_platformosx-arm64version19.1.7
+      osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7:
+        CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64version20.1.8:
-        CONFIG: osx_64_cross_target_platformosx-arm64version20.1.8
+      osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8:
+        CONFIG: osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64version18.1.8:
-        CONFIG: osx_arm64_cross_target_platformosx-64version18.1.8
+      osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1:
+        CONFIG: osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64version19.1.7:
-        CONFIG: osx_arm64_cross_target_platformosx-64version19.1.7
+      osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1:
+        CONFIG: osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64version20.1.8:
-        CONFIG: osx_arm64_cross_target_platformosx-64version20.1.8
+      osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7:
+        CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64version18.1.8:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64version18.1.8
+      osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8:
+        CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64version19.1.7:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64version19.1.7
+      osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7:
+        CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64version20.1.8:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64version20.1.8
+      osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8:
+        CONFIG: osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1.yaml
@@ -1,29 +1,31 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
 - osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
 - x86_64
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 18.1.8
+- 21.1.0.rc1
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -31,3 +33,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1.yaml
@@ -1,29 +1,31 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
 - aarch64
 target_platform:
-- osx-64
+- linux-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 18.1.8
+- 21.1.0.rc1
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -31,3 +33,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7.yaml
@@ -1,27 +1,29 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-macos_machine:
-- arm64-apple-darwin20.0.0
-meson_cpu_family:
-- aarch64
-target_platform:
 - osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+macos_machine:
+- x86_64-apple-darwin13.4.0
+meson_cpu_family:
+- x86_64
+target_platform:
+- linux-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
 - 19.1.7
 zip_keys:
@@ -31,3 +33,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8.yaml
@@ -25,7 +25,7 @@ uname_kernel_release:
 uname_machine:
 - x86_64
 version:
-- 18.1.8
+- 20.1.8
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -33,3 +33,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7.yaml
@@ -1,29 +1,31 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
+- x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
 - aarch64
 target_platform:
-- osx-arm64
+- linux-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 18.1.8
+- 19.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -31,3 +33,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8.yaml
+++ b/.ci_support/linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8.yaml
@@ -1,7 +1,7 @@
 CBUILD:
 - x86_64-conda-linux-gnu
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 cdt_name:
@@ -11,21 +11,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 target_platform:
 - linux-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 19.1.7
+- 20.1.8
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -33,3 +33,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1.yaml
@@ -1,29 +1,29 @@
 CBUILD:
 - x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
-- osx-arm64
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 target_platform:
 - osx-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
-- 20.1.8
+- 21.1.0.rc1
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -31,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1.yaml
@@ -1,29 +1,29 @@
 CBUILD:
-- arm64-apple-darwin20.0.0
-FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
-channel_sources:
-- conda-forge
-channel_targets:
-- conda-forge main
-cross_target_platform:
-- osx-64
-macos_machine:
 - x86_64-apple-darwin13.4.0
-meson_cpu_family:
-- x86_64
-target_platform:
+FINAL_PYTHON_SYSCONFIGDATA_NAME:
+- _sysconfigdata_arm64_apple_darwin20_0_0
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+channel_sources:
+- conda-forge/label/llvm_rc,conda-forge
+channel_targets:
+- conda-forge llvm_rc
+cross_target_platform:
 - osx-arm64
+macos_machine:
+- arm64-apple-darwin20.0.0
+meson_cpu_family:
+- aarch64
+target_platform:
+- osx-64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
-- 19.1.7
+- 21.1.0.rc1
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -31,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7.yaml
@@ -1,29 +1,27 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_arm64_apple_darwin20_0_0
+- _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- osx-64
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 meson_cpu_family:
-- aarch64
+- x86_64
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
-- 20.0.0
+- 13.4.0
 uname_machine:
-- arm64
+- x86_64
 version:
 - 19.1.7
 zip_keys:
@@ -33,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8.yaml
@@ -1,25 +1,23 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - x86_64-apple-darwin13.4.0
 meson_cpu_family:
 - x86_64
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
@@ -33,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7.yaml
@@ -1,31 +1,29 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
 - aarch64
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
 - arm64
 version:
-- 18.1.8
+- 19.1.7
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -33,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8.yaml
+++ b/.ci_support/osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8.yaml
@@ -1,25 +1,23 @@
 CBUILD:
-- x86_64-conda-linux-gnu
+- x86_64-apple-darwin13.4.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 macos_machine:
 - arm64-apple-darwin20.0.0
 meson_cpu_family:
 - aarch64
 target_platform:
-- linux-64
+- osx-64
 uname_kernel_release:
 - 20.0.0
 uname_machine:
@@ -33,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1.yaml
@@ -7,9 +7,9 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
 - osx-64
 macos_machine:
@@ -23,7 +23,7 @@ uname_kernel_release:
 uname_machine:
 - x86_64
 version:
-- 20.1.8
+- 21.1.0.rc1
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -31,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1.yaml
@@ -7,9 +7,9 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_rc
 cross_target_platform:
 - osx-arm64
 macos_machine:
@@ -23,7 +23,7 @@ uname_kernel_release:
 uname_machine:
 - arm64
 version:
-- 20.1.8
+- 21.1.0.rc1
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -31,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7.yaml
@@ -1,11 +1,11 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,7 +17,7 @@ macos_machine:
 meson_cpu_family:
 - x86_64
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
@@ -31,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8.yaml
@@ -1,11 +1,11 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
 - _sysconfigdata_x86_64_apple_darwin13_4_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,13 +17,13 @@ macos_machine:
 meson_cpu_family:
 - x86_64
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
 - 13.4.0
 uname_machine:
 - x86_64
 version:
-- 18.1.8
+- 20.1.8
 zip_keys:
 - - cross_target_platform
   - macos_machine
@@ -31,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7.yaml
@@ -31,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8.yaml
@@ -1,27 +1,27 @@
 CBUILD:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-- _sysconfigdata_x86_64_apple_darwin13_4_0
+- _sysconfigdata_arm64_apple_darwin20_0_0
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 meson_cpu_family:
-- x86_64
+- aarch64
 target_platform:
-- osx-64
+- osx-arm64
 uname_kernel_release:
-- 13.4.0
+- 20.0.0
 uname_machine:
-- x86_64
+- arm64
 version:
 - 20.1.8
 zip_keys:
@@ -31,3 +31,6 @@ zip_keys:
   - uname_machine
   - uname_kernel_release
   - FINAL_PYTHON_SYSCONFIGDATA_NAME
+- - version
+  - channel_sources
+  - channel_targets

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,5 @@ bld.bat text eol=crlf
 /README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true
 build-locally.py linguist-generated=true
+pixi.toml linguist-generated=true
 shippable.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -49,129 +49,129 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cross_target_platformosx-64version18.1.8</td>
+              <td>linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64version18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64version19.1.7</td>
+              <td>linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64version19.1.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64version20.1.8</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64version20.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64version18.1.8</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64version18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64version19.1.7</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64version19.1.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64version20.1.8</td>
+              <td>linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64version20.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64version18.1.8</td>
+              <td>osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64version18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64version19.1.7</td>
+              <td>osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64version19.1.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64version20.1.8</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64version20.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64version18.1.8</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64version18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64version19.1.7</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64version19.1.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64version20.1.8</td>
+              <td>osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64version20.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64version18.1.8</td>
+              <td>osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64version18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-64version21.1.0.rc1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64version19.1.7</td>
+              <td>osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64version19.1.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_llvm_rccross_target_platformosx-arm64version21.1.0.rc1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64version20.1.8</td>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64version20.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64version18.1.8</td>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64version18.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-64version20.1.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64version19.1.7</td>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64version19.1.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version19.1.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64version20.1.8</td>
+              <td>osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7470&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64version20.1.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clang-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_channel_targetsconda-forge_maincross_target_platformosx-arm64version20.1.8" alt="variant">
                 </a>
               </td>
             </tr>
@@ -201,14 +201,14 @@ Current release info
 Installing clang-compiler-activation
 ====================================
 
-Installing `clang-compiler-activation` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `clang-compiler-activation` from the `conda-forge/label/llvm_rc` channel can be achieved by adding `conda-forge/label/llvm_rc` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels conda-forge/label/llvm_rc
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `clang_bootstrap_osx-64, clang_bootstrap_osx-arm64, clang_impl_osx-64, clang_impl_osx-arm64, clang_osx-64, clang_osx-arm64, clangxx_impl_osx-64, clangxx_impl_osx-arm64, clangxx_osx-64, clangxx_osx-arm64` can be installed with `conda`:
+Once the `conda-forge/label/llvm_rc` channel has been enabled, `clang_bootstrap_osx-64, clang_bootstrap_osx-arm64, clang_impl_osx-64, clang_impl_osx-arm64, clang_osx-64, clang_osx-arm64, clangxx_impl_osx-64, clangxx_impl_osx-arm64, clangxx_osx-64, clangxx_osx-arm64` can be installed with `conda`:
 
 ```
 conda install clang_bootstrap_osx-64 clang_bootstrap_osx-arm64 clang_impl_osx-64 clang_impl_osx-arm64 clang_osx-64 clang_osx-arm64 clangxx_impl_osx-64 clangxx_impl_osx-arm64 clangxx_osx-64 clangxx_osx-arm64
@@ -223,26 +223,26 @@ mamba install clang_bootstrap_osx-64 clang_bootstrap_osx-arm64 clang_impl_osx-64
 It is possible to list all of the versions of `clang_bootstrap_osx-64` available on your platform with `conda`:
 
 ```
-conda search clang_bootstrap_osx-64 --channel conda-forge
+conda search clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 ```
 
 or with `mamba`:
 
 ```
-mamba search clang_bootstrap_osx-64 --channel conda-forge
+mamba search clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search clang_bootstrap_osx-64 --channel conda-forge
+mamba repoquery search clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 
 # List packages depending on `clang_bootstrap_osx-64`:
-mamba repoquery whoneeds clang_bootstrap_osx-64 --channel conda-forge
+mamba repoquery whoneeds clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 
 # List dependencies of `clang_bootstrap_osx-64`:
-mamba repoquery depends clang_bootstrap_osx-64 --channel conda-forge
+mamba repoquery depends clang_bootstrap_osx-64 --channel conda-forge/label/llvm_rc
 ```
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,19 +9,19 @@ MACOSX_DEPLOYMENT_TARGET:  # [linux]
   - 10.9                   # [linux]
 
 version:
-  - 19.1.7
-  - 20.1.8
   - 21.1.0.rc1
+  - 20.1.8
+  - 19.1.7
 
 # zip to avoid using rc-builds for already-released-in-conda-forge LLVM versions
 channel_sources:
-  - conda-forge
-  - conda-forge
   - conda-forge/label/llvm_rc,conda-forge
+  - conda-forge
+  - conda-forge
 channel_targets:
-  - conda-forge main
-  - conda-forge main
   - conda-forge llvm_rc
+  - conda-forge main
+  - conda-forge main
 
 # everything below is zipped
 cross_target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,6 +13,16 @@ version:
   - 19.1.7
   - 20.1.8
 
+# zip to avoid using rc-builds for already-released-in-conda-forge LLVM versions
+channel_sources:
+  - conda-forge
+  - conda-forge
+  - conda-forge/label/llvm_rc,conda-forge
+channel_targets:
+  - conda-forge main
+  - conda-forge main
+  - conda-forge llvm_rc
+
 # everything below is zipped
 cross_target_platform:
   - osx-64
@@ -41,3 +51,7 @@ zip_keys:
     - uname_machine
     - uname_kernel_release
     - FINAL_PYTHON_SYSCONFIGDATA_NAME
+  -
+    - version
+    - channel_sources
+    - channel_targets

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,9 +9,9 @@ MACOSX_DEPLOYMENT_TARGET:  # [linux]
   - 10.9                   # [linux]
 
 version:
-  - 18.1.8
   - 19.1.7
   - 20.1.8
+  - 21.1.0.rc1
 
 # zip to avoid using rc-builds for already-released-in-conda-forge LLVM versions
 channel_sources:


### PR DESCRIPTION
A new feedstock joins the party, now we have flang-rt too. :)

### List form

Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency):

* [x] https://github.com/conda-forge/libcxx-feedstock/pull/235
* [x] https://github.com/conda-forge/llvmdev-feedstock/pull/332
  * [x] https://github.com/conda-forge/clangdev-feedstock/pull/365 (also needs libcxx)
    * [x] https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/87 (major-only)
    * [x] https://github.com/conda-forge/compiler-rt-feedstock/pull/147
      * [x] https://github.com/conda-forge/openmp-feedstock/pull/180
  * [x] https://github.com/conda-forge/lld-feedstock/pull/130

Clang v20.1 for other platforms (major-only):
* [ ] https://github.com/conda-forge/clang-win-activation-feedstock
* [ ] https://github.com/conda-forge/ctng-compiler-activation-feedstock
* [ ] https://github.com/conda-forge/r_clang_activation-feedstock

Other LLVM-related feedstocks:
* [x] https://github.com/conda-forge/mlir-feedstock/pull/103 (needs llvmdev)
  * [x] https://github.com/conda-forge/flang-feedstock/pull/109 (also needs compiler-rt)
    * [ ] https://github.com/conda-forge/flang-rt-feedstock/pull/2
      * [ ] https://github.com/conda-forge/flang-activation-feedstock/pull/32 (also needs lld)
* [ ] https://github.com/conda-forge/libcxx-testing-feedstock (major-only)
* [ ] https://github.com/conda-forge/lldb-feedstock (needs this PR)
* [ ] https://github.com/conda-forge/mlir-python-bindings-feedstock (needs mlir & this PR)