### PR TITLE
LLVM 21.1.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,7 +9,7 @@ MACOSX_DEPLOYMENT_TARGET:  # [linux]
   - 10.9                   # [linux]
 
 version:
-  - 21.1.2
+  - 21.1.3
   - 20.1.8
   - 19.1.7
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% if version is not defined %}
-{% set version = "21.1.2" %}
+{% set version = "21.1.3" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 # in the past we've had to uncouple the compiler version from the version


### PR DESCRIPTION
Blockers for merging this PR and thus enabling the compilers in conda-forge (indentation denotes dependency):

* [ ] https://github.com/conda-forge/libcxx-feedstock/pull/250
* [x] https://github.com/conda-forge/llvmdev-feedstock/pull/349
  * [ ] https://github.com/conda-forge/clangdev-feedstock/pull/391 (also needs libcxx)
    * [x] https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/89 (major-only)
    * [ ] https://github.com/conda-forge/compiler-rt-feedstock/pull/161
      * [ ] https://github.com/conda-forge/openmp-feedstock/pull/194
  * [ ] https://github.com/conda-forge/lld-feedstock/pull/142

Other LLVM-related feedstocks:
* [ ] https://github.com/conda-forge/mlir-feedstock/pull/110 (needs llvmdev)
  * [ ] https://github.com/conda-forge/flang-feedstock/pull/115 (also needs compiler-rt)
    * [ ] https://github.com/conda-forge/flang-rt-feedstock/pull/9
      * [ ] https://github.com/conda-forge/flang-activation-feedstock/pull/39 (also needs lld)
* [ ] https://github.com/conda-forge/libcxx-testing-feedstock/pull/17 (major-only)
* [ ] https://github.com/conda-forge/lldb-feedstock/pull/95 (needs this PR)
* [ ] https://github.com/conda-forge/mlir-python-bindings-feedstock/pull/60 (needs mlir & this PR)