### PR TITLE
Workaround for rattler-build setting target_platform = noarch

### DIFF
--- a/recipe/activate-clang++.sh
+++ b/recipe/activate-clang++.sh
@@ -121,7 +121,7 @@ else
 fi
 }
 
-if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && [ "${target_platform:-@TARGET_PLATFORM@}" != "@TARGET_PLATFORM@" ]; then
+if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && { [ "${target_platform:-@TARGET_PLATFORM@}" != "@TARGET_PLATFORM@" ] || [ "${target_platform}" = "noarch" ]; }; then
    echo "Not activating environment because this compiler is not expected."
 else
   activate_clangxx

--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -212,7 +212,7 @@ else
 fi
 }
 
-if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && [ "${target_platform:-@TARGET_PLATFORM@}" != "@TARGET_PLATFORM@" ]; then
+if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && { [ "${target_platform:-@TARGET_PLATFORM@}" != "@TARGET_PLATFORM@" ] || [ "${target_platform}" = "noarch" ]; }; then
   echo "Not activating environment because this compiler is not expected."
 else
   activate_clang

--- a/recipe/deactivate-clang++.sh
+++ b/recipe/deactivate-clang++.sh
@@ -122,7 +122,7 @@ else
 fi
 }
 
-if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && [ "${target_platform:-@TARGET_PLATFORM@}" != "@TARGET_PLATFORM@" ]; then
+if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && { [ "${target_platform:-@TARGET_PLATFORM@}" != "@TARGET_PLATFORM@" ] || [ "${target_platform}" = "noarch" ]; }; then
   echo "Not deactivating environment because this compiler is not expected."
 else
   deactivate_clangxx

--- a/recipe/deactivate-clang.sh
+++ b/recipe/deactivate-clang.sh
@@ -160,7 +160,7 @@ else
 fi
 }
 
-if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && [ "${target_platform:-@TARGET_PLATFORM@}" != "@TARGET_PLATFORM@" ]; then
+if [ "${CONDA_BUILD_STATE:-0}" = "BUILD" ] && { [ "${target_platform:-@TARGET_PLATFORM@}" != "@TARGET_PLATFORM@" ] || [ "${target_platform}" = "noarch" ]; }; then
   echo "Not deactivating environment because this compiler is not expected."
 else
   deactivate_clang

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 # of the C++ stdlib; keep the variable in case this happens again
 {% set libcxx_major = major_ver %}
 
-{% set build_number = 31 %}
+{% set build_number = 32 %}
 
 package:
   name: clang-compiler-activation


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
